### PR TITLE
Fixes a typo in the resource files

### DIFF
--- a/resources/locales/de.json
+++ b/resources/locales/de.json
@@ -56,7 +56,7 @@
     "success": "Erfolg",
     "failure": "Fehler",
     "emptyName": "Bitte geben Sie einen Namen ein",
-    "addFiled": "Programm konnte nicht gespeichert werden:",
+    "addFailed": "Programm konnte nicht gespeichert werden:",
     "nameTaken": "Name ist bereits vergeben",
     "duplicateFailed": "Programm konnte nicht dupliziert werden:",
     "deleteFailed": "Programm konnte nicht gelöscht werden:",

--- a/resources/locales/en.json
+++ b/resources/locales/en.json
@@ -56,7 +56,7 @@
     "success": "Success",
     "failure": "Failure",
     "emptyName": "Please enter a name",
-    "addFiled": "Failed to save program: ",
+    "addFailed": "Failed to save program: ",
     "nameTaken": "Name is already taken",
     "duplicateFailed": "Failed to duplicate program: ",
     "deleteFailed": "Failed to delete program: ",


### PR DESCRIPTION
In the code the correct language resource is accessed with

    i18n.t('RoboticsDatabase.addFailed')

